### PR TITLE
Removed the Student.belongsTo(models.Tutor)

### DIFF
--- a/models/student.js
+++ b/models/student.js
@@ -24,7 +24,6 @@ module.exports = function (sequelize, DataTypes) {
     });
 
 
-        // Student.belongsTo(models.Tutor);
         // Student.belongsToMany(models.Class, {
         //     through: models.Roster,
         //     unique: false


### PR DESCRIPTION
The belongsTo is for one to one associations. The association in the tutor model should suffice to create the necessary association.