### PR TITLE
Removed the belongsTo associations

### DIFF
--- a/models/message.js
+++ b/models/message.js
@@ -26,9 +26,6 @@ module.exports = function (sequelize, DataTypes) {
         }
     });
 
-    // Message.belongsTo(models.Tutor);
-    // Message.belongsTo(models.Teacher);
-
     return Message;
 
 }


### PR DESCRIPTION
I removed the belongsTo associations because those are for one to one relationships. The hasMany association needs to be used in the tutor and teacher models to create the correct associations.